### PR TITLE
Add draggable board occupants with turn-based interactions

### DIFF
--- a/Assets/Scripts/ClickToMove.cs
+++ b/Assets/Scripts/ClickToMove.cs
@@ -6,8 +6,19 @@ public class ClickToMove : MonoBehaviour
     public Camera cam;
     public LayerMask groundMask = ~0; // optional: limit raycast
 
+    [Header("Drag Interactions")]
+    [Tooltip("Physics layers considered when searching for draggable occupants.")]
+    public LayerMask draggableMask = ~0;
+    [Tooltip("Maximum distance used when raycasting to find draggable occupants.")]
+    public float dragRayDistance = 100f;
+
     PlayerAgent _agent;
     Grid2D _grid;
+    DragInteractable _activeDrag;
+    int _activePointerId = kNoPointer;
+
+    const int kMousePointer = -1;
+    const int kNoPointer = int.MinValue;
 
     void Awake()
     {
@@ -30,17 +41,35 @@ public class ClickToMove : MonoBehaviour
             if (_agent.gameManager.IsGameOver || !_agent.gameManager.IsPlayerTurn) return;
         }
 
-        if (Input.GetMouseButtonDown(0))
+        if (_activeDrag != null)
         {
-            if (RaycastToGrid(Input.mousePosition, out Vector2Int cell))
-                _agent.TryMoveToCell(cell);
+            HandleActiveDrag();
+            return;
         }
 
-        // (Optional) Simple touch
-        if (Input.touchCount == 1 && Input.GetTouch(0).phase == TouchPhase.Began)
+        if (Input.GetMouseButtonDown(0))
         {
-            if (RaycastToGrid(Input.GetTouch(0).position, out Vector2Int cell))
+            if (!TryBeginDrag(Input.mousePosition, kMousePointer))
+            {
+                if (RaycastToGrid(Input.mousePosition, out Vector2Int cell))
+                    _agent.TryMoveToCell(cell);
+            }
+            return;
+        }
+
+        // Touch support (single touch for movement/drag)
+        for (int i = 0; i < Input.touchCount; i++)
+        {
+            var touch = Input.GetTouch(i);
+            if (touch.phase != TouchPhase.Began) continue;
+
+            if (TryBeginDrag(touch.position, touch.fingerId))
+                return;
+
+            if (RaycastToGrid(touch.position, out Vector2Int cell))
                 _agent.TryMoveToCell(cell);
+
+            return; // handle only first began touch per frame
         }
     }
 
@@ -56,5 +85,125 @@ public class ClickToMove : MonoBehaviour
             return _grid.WorldToCell(hit, out cell);
         }
         return false;
+    }
+
+    bool RaycastToPlane(Vector2 screenPos, out Vector3 world)
+    {
+        world = default;
+        Ray ray = cam.ScreenPointToRay(screenPos);
+        var plane = new Plane(Vector3.up, new Vector3(0f, _grid.gridY, 0f));
+        if (plane.Raycast(ray, out float enter))
+        {
+            world = ray.GetPoint(enter);
+            return true;
+        }
+        return false;
+    }
+
+    bool TryBeginDrag(Vector2 screenPos, int pointerId)
+    {
+        if (_agent.IsMoving) return false;
+        if (_agent.gameManager != null && !_agent.gameManager.IsPlayerTurn) return false;
+
+        Ray ray = cam.ScreenPointToRay(screenPos);
+        if (Physics.Raycast(ray, out var hit, dragRayDistance, draggableMask, QueryTriggerInteraction.Collide))
+        {
+            var drag = hit.collider.GetComponentInParent<DragInteractable>();
+            if (drag != null && drag.CanBeginDrag())
+            {
+                Vector3 pointerWorld;
+                if (!RaycastToPlane(screenPos, out pointerWorld))
+                    pointerWorld = hit.point;
+
+                if (!drag.BeginDrag(pointerWorld))
+                    return false;
+
+                _activeDrag = drag;
+                _activePointerId = pointerId;
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    void HandleActiveDrag()
+    {
+        if (_activeDrag == null) return;
+
+        if (_activePointerId == kMousePointer)
+        {
+            if (Input.GetMouseButton(0))
+            {
+                if (RaycastToPlane(Input.mousePosition, out var world))
+                    _activeDrag.UpdateDrag(world);
+            }
+
+            if (Input.GetMouseButtonUp(0))
+            {
+                FinishDrag(Input.mousePosition);
+            }
+        }
+        else
+        {
+            bool found = false;
+            for (int i = 0; i < Input.touchCount; i++)
+            {
+                var touch = Input.GetTouch(i);
+                if (touch.fingerId != _activePointerId) continue;
+                found = true;
+
+                if (touch.phase == TouchPhase.Moved || touch.phase == TouchPhase.Stationary)
+                {
+                    if (RaycastToPlane(touch.position, out var world))
+                        _activeDrag.UpdateDrag(world);
+                }
+
+                if (touch.phase == TouchPhase.Ended || touch.phase == TouchPhase.Canceled)
+                {
+                    FinishDrag(touch.position, touch.phase == TouchPhase.Canceled);
+                }
+                break;
+            }
+
+            if (!found)
+            {
+                CancelActiveDrag();
+            }
+        }
+    }
+
+    void FinishDrag(Vector2 screenPos, bool canceled = false)
+    {
+        if (_activeDrag == null) return;
+
+        bool moved = false;
+        if (canceled)
+        {
+            _activeDrag.CancelDrag();
+        }
+        else
+        {
+            Vector3 world;
+            if (!RaycastToPlane(screenPos, out world))
+                world = _activeDrag.transform.position;
+            moved = _activeDrag.EndDrag(world);
+        }
+
+        if (moved && _agent.gameManager != null)
+        {
+            _agent.gameManager.NotifyPlayerTurnEnded(_agent);
+        }
+
+        _activeDrag = null;
+        _activePointerId = kNoPointer;
+    }
+
+    void CancelActiveDrag()
+    {
+        if (_activeDrag == null) return;
+        _activeDrag.CancelDrag();
+        _activeDrag = null;
+        _activePointerId = kNoPointer;
     }
 }

--- a/Assets/Scripts/DragInteractable.cs
+++ b/Assets/Scripts/DragInteractable.cs
@@ -1,0 +1,239 @@
+using UnityEngine;
+
+/// <summary>
+/// Adds drag-based interaction to a board occupant. Supports translation along a single axis or rotation
+/// around a single axis with snapping behaviour. Designed to be controlled by <see cref="ClickToMove"/>.
+/// </summary>
+[DisallowMultipleComponent]
+public class DragInteractable : MonoBehaviour
+{
+    public enum DragMode
+    {
+        Translation,
+        Rotation
+    }
+
+    [Header("General")]
+    public DragMode mode = DragMode.Translation;
+    public Grid2D grid;
+
+    [Header("Translation")]
+    [Tooltip("Axis in grid-space (X/Z plane) the object is allowed to move along.")]
+    public Vector2Int translationAxis = Vector2Int.right;
+    [Tooltip("Minimum number of cell steps from the start position.")]
+    public int minTranslationSteps = -1;
+    [Tooltip("Maximum number of cell steps from the start position.")]
+    public int maxTranslationSteps = 1;
+
+    [Header("Rotation")]
+    [Tooltip("Axis around which the object rotates while dragging.")]
+    public Vector3 rotationAxis = Vector3.up;
+    [Tooltip("Angle in degrees per snap step.")]
+    public float rotationSnapAngle = 90f;
+    [Tooltip("Minimum number of snap steps relative to the start rotation.")]
+    public int minRotationSteps = -1;
+    [Tooltip("Maximum number of snap steps relative to the start rotation.")]
+    public int maxRotationSteps = 1;
+
+    [Header("Board Update")]
+    [Tooltip("If true, SyncCellFromWorld() is invoked on any IBoardCellOccupant found on this object after drag completes.")]
+    public bool resyncOccupantAfterDrag = true;
+
+    IBoardCellOccupant _occupant;
+    IBoardAffectsWalkability _blocker;
+
+    bool _dragging;
+    Vector3 _startWorld;
+    Quaternion _startRotation;
+    Vector3 _pivotWorld;
+    Vector3 _rotationAxisWorld;
+    Vector3 _translationAxisWorld;
+    int _currentStep;
+
+    void Awake()
+    {
+        _occupant = GetComponent<IBoardCellOccupant>();
+        _blocker = GetComponent<IBoardAffectsWalkability>();
+        if (grid == null && _occupant != null)
+            grid = _occupant.GetGrid();
+    }
+
+    /// <summary>Returns false when the drag should be rejected (invalid setup or currently dragging).</summary>
+    public bool CanBeginDrag()
+    {
+        if (_dragging) return false;
+        var g = ResolveGrid();
+        if (g == null) return false;
+
+        if (mode == DragMode.Translation)
+        {
+            if (translationAxis == Vector2Int.zero) return false;
+            if (minTranslationSteps > maxTranslationSteps) return false;
+            if (minTranslationSteps == 0 && maxTranslationSteps == 0) return false;
+        }
+        else if (mode == DragMode.Rotation)
+        {
+            if (rotationSnapAngle <= 0.0001f) return false;
+            if (rotationAxis.sqrMagnitude < 0.0001f) return false;
+            if (minRotationSteps > maxRotationSteps) return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>Initialises drag at the provided pointer position projected on the grid plane.</summary>
+    public bool BeginDrag(Vector3 pointerWorldPosition)
+    {
+        if (!CanBeginDrag()) return false;
+
+        _dragging = true;
+        _startWorld = transform.position;
+        _startRotation = transform.rotation;
+        _currentStep = 0;
+
+        var g = ResolveGrid();
+        if (mode == DragMode.Translation)
+        {
+            _translationAxisWorld = new Vector3(translationAxis.x, 0f, translationAxis.y);
+            if (_translationAxisWorld.sqrMagnitude < 0.0001f)
+                _translationAxisWorld = Vector3.right;
+            _translationAxisWorld.y = 0f;
+            _translationAxisWorld = _translationAxisWorld.normalized;
+        }
+        else
+        {
+            _rotationAxisWorld = rotationAxis.sqrMagnitude < 0.0001f ? Vector3.up : rotationAxis.normalized;
+            _pivotWorld = transform.position;
+            _rotationAxisWorld.Normalize();
+        }
+
+        UpdateDrag(pointerWorldPosition);
+        return true;
+    }
+
+    public void UpdateDrag(Vector3 pointerWorldPosition)
+    {
+        if (!_dragging) return;
+
+        var g = ResolveGrid();
+        if (g == null) return;
+
+        if (mode == DragMode.Translation)
+        {
+            Vector3 planePos = ProjectPointToPlane(pointerWorldPosition, g.gridY);
+            Vector3 delta = planePos - _startWorld;
+            float axisDistance = Vector3.Dot(delta, _translationAxisWorld);
+            float stepFloat = axisDistance / Mathf.Max(0.0001f, g.cellSize);
+            int desiredStep = Mathf.RoundToInt(stepFloat);
+            desiredStep = Mathf.Clamp(desiredStep, minTranslationSteps, maxTranslationSteps);
+
+            if (desiredStep != _currentStep)
+            {
+                _currentStep = desiredStep;
+            }
+
+            Vector3 snapped = _startWorld + _translationAxisWorld * (g.cellSize * _currentStep);
+            snapped.y = _startWorld.y;
+            transform.position = snapped;
+        }
+        else
+        {
+            Vector3 planePos = ProjectPointToPlane(pointerWorldPosition, g.gridY);
+            Vector3 fromStart = ProjectVectorOnPlane(_startRotation * Vector3.forward, _rotationAxisWorld);
+            if (fromStart.sqrMagnitude < 0.0001f)
+            {
+                fromStart = ProjectVectorOnPlane(transform.forward, _rotationAxisWorld);
+            }
+            Vector3 currentDir = ProjectVectorOnPlane(planePos - _pivotWorld, _rotationAxisWorld);
+            if (currentDir.sqrMagnitude < 0.0001f)
+            {
+                currentDir = fromStart;
+            }
+
+            fromStart.Normalize();
+            currentDir.Normalize();
+
+            float signedAngle = Vector3.SignedAngle(fromStart, currentDir, _rotationAxisWorld);
+            float stepFloat = signedAngle / Mathf.Max(0.0001f, rotationSnapAngle);
+            int desiredStep = Mathf.RoundToInt(stepFloat);
+            desiredStep = Mathf.Clamp(desiredStep, minRotationSteps, maxRotationSteps);
+
+            if (desiredStep != _currentStep)
+            {
+                _currentStep = desiredStep;
+            }
+
+            float snappedAngle = rotationSnapAngle * _currentStep;
+            transform.rotation = _startRotation * Quaternion.AngleAxis(snappedAngle, _rotationAxisWorld);
+        }
+    }
+
+    /// <summary>
+    /// Finalises the drag interaction. Returns true if the object ended up in a new snap step.
+    /// </summary>
+    public bool EndDrag(Vector3 pointerWorldPosition)
+    {
+        if (!_dragging) return false;
+
+        UpdateDrag(pointerWorldPosition);
+
+        bool moved = _currentStep != 0;
+        if (!moved)
+        {
+            // revert fully to initial state if no movement happened
+            transform.position = _startWorld;
+            transform.rotation = _startRotation;
+        }
+
+        _dragging = false;
+
+        if (moved)
+        {
+            PostDragSync();
+        }
+
+        return moved;
+    }
+
+    public void CancelDrag()
+    {
+        if (!_dragging) return;
+        _dragging = false;
+        transform.position = _startWorld;
+        transform.rotation = _startRotation;
+    }
+
+    void PostDragSync()
+    {
+        var g = ResolveGrid();
+        if (g == null) return;
+
+        if (resyncOccupantAfterDrag && _occupant != null)
+        {
+            _occupant.SyncCellFromWorld();
+        }
+
+        if (_blocker != null)
+        {
+            g.NotifyDynamicOccupantMoved(_blocker);
+        }
+    }
+
+    Grid2D ResolveGrid()
+    {
+        if (grid != null) return grid;
+        if (_occupant != null) grid = _occupant.GetGrid();
+        return grid;
+    }
+
+    static Vector3 ProjectPointToPlane(Vector3 point, float planeY)
+    {
+        point.y = planeY;
+        return point;
+    }
+
+    static Vector3 ProjectVectorOnPlane(Vector3 vector, Vector3 normal)
+    {
+        return Vector3.ProjectOnPlane(vector, normal);
+    }
+}


### PR DESCRIPTION
## Summary
- add a DragInteractable component that supports snapped translation or rotation drags and refreshes board occupancy
- extend ClickToMove to prioritize draggable targets, run drag sessions with mouse or touch, and consume the player turn when a drag succeeds

## Testing
- not run (Unity project)

------
https://chatgpt.com/codex/tasks/task_e_68ccddf82de4832da2d4b90140e94142