### PR TITLE
Refactor resources to turns and remove health

### DIFF
--- a/Assets/Prefabs/Buff.prefab
+++ b/Assets/Prefabs/Buff.prefab
@@ -45,7 +45,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e7599445805b5984396111f82860273c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  power: 1
+  extraTurns: 1
   triggerOnTurnEndOnly: 1
   grid: {fileID: 0}
 --- !u!1001 &3978387870814737037

--- a/Assets/Prefabs/Enemy.prefab
+++ b/Assets/Prefabs/Enemy.prefab
@@ -135,7 +135,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   range: 1
-  power: 2
   triggerOnTurnEndOnly: 1
   grid: {fileID: 0}
 --- !u!114 &6043555654375149453

--- a/Assets/Prefabs/Spikes.prefab
+++ b/Assets/Prefabs/Spikes.prefab
@@ -92,7 +92,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   range: 0
-  power: 1
   triggerOnTurnEndOnly: 1
   grid: {fileID: 0}
 --- !u!1001 &2406896929179265

--- a/Assets/Scenes/PrototypeScene 1.unity
+++ b/Assets/Scenes/PrototypeScene 1.unity
@@ -594,9 +594,6 @@ MonoBehaviour:
   onLose:
     m_PersistentCalls:
       m_Calls: []
-  onHealthChanged:
-    m_PersistentCalls:
-      m_Calls: []
   movers: []
   enemies:
   - {fileID: 2094140864}
@@ -3408,9 +3405,7 @@ MonoBehaviour:
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4
-  maxHealth: 10
-  currentHealth: 0
-  maxStepsPerTurn: 5
+  cellsPerTurn: 5
 --- !u!136 &1204494851
 CapsuleCollider:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/PrototypeScene 2.unity
+++ b/Assets/Scenes/PrototypeScene 2.unity
@@ -526,9 +526,6 @@ MonoBehaviour:
   onLose:
     m_PersistentCalls:
       m_Calls: []
-  onHealthChanged:
-    m_PersistentCalls:
-      m_Calls: []
   movers: []
   enemies:
   - {fileID: 2094140864}
@@ -3280,9 +3277,7 @@ MonoBehaviour:
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4
-  maxHealth: 10
-  currentHealth: 0
-  maxStepsPerTurn: 5
+  cellsPerTurn: 5
 --- !u!136 &1204494851
 CapsuleCollider:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Buff.cs
+++ b/Assets/Scripts/Buff.cs
@@ -4,8 +4,8 @@ using UnityEngine;
 public class Buff : MonoBehaviour, IBoardCellOccupant
 {
     [Header("Buff")]
-    [Min(1)] public int power = 1;             // health gained on consume
-    [Tooltip("Buffs trigger only if the player ENDS a turn on this exact cell.")]
+    [Min(1)] public int extraTurns = 1;        // additional turns granted on consume
+    [Tooltip("If true, the buff only triggers when the player finishes their move on this cell.")]
     public bool triggerOnTurnEndOnly = true;   // remains for consistency
     public bool consumed { get; private set; } // persisted only while scene runs
 
@@ -52,18 +52,23 @@ public class Buff : MonoBehaviour, IBoardCellOccupant
 
         #if UNITY_EDITOR
         UnityEditor.Handles.color = consumed ? new Color(0.6f, 0.9f, 0.9f, 0.6f) : new Color(0f, 1f, 1f, 1f);
-        UnityEditor.Handles.Label(center + new Vector3(0, 0.03f, 0), consumed ? $"BUFF (used)" : $"BUFF +{power} HP");
+        UnityEditor.Handles.Label(center + new Vector3(0, 0.03f, 0), consumed ? $"BUFF (used)" : $"BUFF +{extraTurns} Turn{(extraTurns > 1 ? "s" : string.Empty)}");
         #endif
     }
 #endif
 
-    /// <summary>Called in AI turn if the player ended their move on this cell.</summary>
-    public int ConsumeIfApplicable(Vector2Int playerCell)
+    /// <summary>Consumes the buff if the player occupies this cell.</summary>
+    /// <param name="playerCell">Player's current cell.</param>
+    /// <param name="triggeredDuringMovement">True if the player is still moving towards another cell.</param>
+    /// <returns>The number of extra turns granted.</returns>
+    public int Consume(Vector2Int playerCell, bool triggeredDuringMovement)
     {
         if (consumed) return 0;
         if (playerCell != Cell) return 0; // range is exactly 0
+        if (triggerOnTurnEndOnly && triggeredDuringMovement) return 0;
+
         consumed = true;
         gameObject.SetActive(false);
-        return power;
+        return Mathf.Max(0, extraTurns);
     }
 }

--- a/Assets/Scripts/Enemy.cs
+++ b/Assets/Scripts/Enemy.cs
@@ -5,7 +5,6 @@ public class Enemy : MonoBehaviour, IBoardCellOccupant
 {
     [Header("Enemy Stats")]
     [Min(0)] public int range = 0;  // Manhattan range
-    [Min(0)] public int power = 1;  // Health lost if player ends turn within range
     [Tooltip("If true, only triggers when the player ENDS a turn; passing through mid-path has no effect.")]
     public bool triggerOnTurnEndOnly = true;
 

--- a/Assets/Scripts/Hud.cs
+++ b/Assets/Scripts/Hud.cs
@@ -15,11 +15,10 @@ public class Hud : MonoBehaviour
     
     void Start()
     {
-        OnEnergyChanged(m_PlayerAgent.maxHealth, m_PlayerAgent.currentHealth);
-        
+        UpdateEnergyDisplay();
+
         m_GameManager.onWin.AddListener(OnWin);
         m_GameManager.onLose.AddListener(OnLose);
-        m_GameManager.onHealthChanged.AddListener(OnEnergyChanged);
     }
 
     void OnWin()
@@ -32,8 +31,9 @@ public class Hud : MonoBehaviour
         m_LosePanel.gameObject.SetActive(true);
     }
     
-    void OnEnergyChanged(int current, int max)
+    void UpdateEnergyDisplay()
     {
-        m_EnergyText.text = $"H: {current}";
+        if (m_PlayerAgent == null || m_EnergyText == null) return;
+        m_EnergyText.text = $"Energy: {m_PlayerAgent.CellsPerTurn} cells/turn";
     }
 }


### PR DESCRIPTION
## Summary
- remove the unused health resource and treat player energy as the number of cells that can be travelled each turn
- update the player, game manager, and buff logic so buffs grant extra turns while hazards immediately end the game
- refresh UI, prefabs, and scenes to reflect the new turn-based resource data

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ccf000de20832d96efede35d66f968